### PR TITLE
Visually Hidden component

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dist/*"
   ],
   "dependencies": {
+    "@reach/visually-hidden": "^0.1.2",
     "classnames": "^2.2.6",
     "focus-trap-react": "^6.0.0",
     "prop-types": "^15.7.2",

--- a/src/Components/VisuallyHidden/Readme.md
+++ b/src/Components/VisuallyHidden/Readme.md
@@ -1,0 +1,16 @@
+* Provides text for screen readers that is visually hidden.
+* It is the logical opposite of the `aria-hidden` attribute.
+* For full documentation, see [https://ui.reach.tech/visually-hidden/](https://ui.reach.tech/visually-hidden/)
+
+### Example
+
+In the following example, screen readers will announce "Add Item" and will ignore the icon; the browser displays the icon and ignores the text.
+
+```js
+import Icon from '../Icon/Icon';
+import Button from '../Button/Button';
+<Button type="button">
+  <VisuallyHidden>Add Item</VisuallyHidden>
+  <Icon name="add-circle" />
+</Button>
+```

--- a/src/Components/VisuallyHidden/VisuallyHidden.js
+++ b/src/Components/VisuallyHidden/VisuallyHidden.js
@@ -1,0 +1,3 @@
+import VisuallyHidden from '@reach/visually-hidden';
+
+export default VisuallyHidden;

--- a/src/Components/VisuallyHidden/VisuallyHidden.test.js
+++ b/src/Components/VisuallyHidden/VisuallyHidden.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import VisuallyHidden from './VisuallyHidden';
+
+describe('VisuallyHidden', () => {
+  it('renders without crashing', () => {
+    expect(() => { shallow(<VisuallyHidden>hello</VisuallyHidden>); }).not.toThrow();
+  });
+});

--- a/src/Components/VisuallyHidden/stories.js
+++ b/src/Components/VisuallyHidden/stories.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import Icon from '../Icon/Icon';
+import Button from '../Button/Button';
+import VisuallyHidden from './VisuallyHidden';
+
+storiesOf('VisuallyHidden', module)
+  .add('all', () => (
+    <Button type="button">
+      <VisuallyHidden>Add Item</VisuallyHidden>
+      <Icon name="add-circle" />
+    </Button>
+  ));

--- a/src/Components/index.js
+++ b/src/Components/index.js
@@ -30,3 +30,4 @@ export { default as Tab } from './Tabs/Components/Tab';
 export { default as TabPanel } from './Tabs/Components/TabPanel';
 export { default as Text } from './Text/Text';
 export { default as TextContainer } from './TextContainer/TextContainer';
+export { default as VisuallyHidden } from './VisuallyHidden/VisuallyHidden';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1338,6 +1338,11 @@
     react-lifecycles-compat "^3.0.4"
     warning "^3.0.0"
 
+"@reach/visually-hidden@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@reach/visually-hidden/-/visually-hidden-0.1.2.tgz#96605cdcbd4585c76b56fed779904423e1f87794"
+  integrity sha512-x/ewdWFlUphyF4pEth5U2FNS29vz/OOxAKcxc+XWbX96XUTobfIvLjYfQWawcP6+Eavy7zGvobpeHj7GVegTRA==
+
 "@storybook/addon-a11y@^5.0.10":
   version "5.0.10"
   resolved "https://registry.yarnpkg.com/@storybook/addon-a11y/-/addon-a11y-5.0.10.tgz#406fb5d806ced78f1ed129cfd56af1c7fc9b5485"


### PR DESCRIPTION
Documented convenience wrapper for https://ui.reach.tech/visually-hidden/

* Provides text for screen readers that is visually hidden.
* It is the logical opposite of the `aria-hidden` attribute.
* For full documentation, see [https://ui.reach.tech/visually-hidden/](https://ui.reach.tech/visually-hidden/)