### PR TITLE
Fixes table row null child rendering crash

### DIFF
--- a/src/Components/Table/Components/TableRow.js
+++ b/src/Components/Table/Components/TableRow.js
@@ -48,7 +48,7 @@ function TableRow({
   );
 
   const childrenMarkup = () => (
-    React.Children.map(children, (child, i) => React.cloneElement(
+    React.Children.map(children, (child, i) => child && React.cloneElement(
       child,
       {
         'aria-colindex': i + 1

--- a/src/Components/Table/Components/TableRow.test.js
+++ b/src/Components/Table/Components/TableRow.test.js
@@ -16,6 +16,13 @@ describe('TableRow', () => {
     expect(() => { shallow(<TableRow />); }).not.toThrow();
   });
 
+  it('renders blank children without crashing', () => {
+    const wrapper = shallow(<TableRow>
+      {null}
+      <div></div>
+    </TableRow>)
+  })
+
   it('sets the direction to row when not mobile', () => {
     const wrapper = shallow(<TableRow />);
     expect(wrapper.prop('direction')).toBe('row');


### PR DESCRIPTION
According to the [Conditional Rendering docs](https://reactjs.org/docs/conditional-rendering.html) it's valid to return `null` instead of a component and this gets used to selectively insert a column in Commander.

Currently it causes a crash when trying to switch to using the `Table` Pebble components. This PR fixes it by only cloning if the element actually exists.