### PR TITLE
fix: Updating proptypes to not warn for multiple children within Block

### DIFF
--- a/src/Components/Block/Block.js
+++ b/src/Components/Block/Block.js
@@ -94,7 +94,7 @@ const propTypes = {
   /**
    * Elements to be rendered as children of this component
    */
-  children: PropTypes.node,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   /**
    * Orientation to layout children
    *


### PR DESCRIPTION
This change updates Block's propTypes to accept both a single child or array of children. Currently Block will issue propType warnings in the console when more than one child is passed to it.

ref: https://stackoverflow.com/a/42122662