### PR TITLE
fix (FieldNumber, FieldText): allow node to be used as prefix and suffix

### DIFF
--- a/src/Components/FieldNumber/FieldNumber.js
+++ b/src/Components/FieldNumber/FieldNumber.js
@@ -76,13 +76,13 @@ const propTypes = {
    */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   /**
-   * Text to display before the value
+   * Text or node to display before the value
    */
-  prefix: PropTypes.string,
+  prefix: PropTypes.node,
   /**
-   * Text to display after the value
+   * Text or node to display after the value
    */
-  suffix: PropTypes.string,
+  suffix: PropTypes.node,
   /**
    * Text to display if the input is invalid.
    * The text should explain why the input is invalid.

--- a/src/Components/FieldText/FieldText.js
+++ b/src/Components/FieldText/FieldText.js
@@ -93,13 +93,13 @@ const propTypes = {
     'url',
   ]),
   /**
-   * Text to display before the value
+   * Text or node to display before the value
    */
-  prefix: PropTypes.string,
+  prefix: PropTypes.node,
   /**
-   * Text to display after the value
+   * Text or node to display after the value
    */
-  suffix: PropTypes.string,
+  suffix: PropTypes.node,
   /**
    * Text to display if the input is invalid.
    * The text should explain why the input is invalid.

--- a/src/Components/Input/Input.js
+++ b/src/Components/Input/Input.js
@@ -66,9 +66,9 @@ const propTypes = {
    */
   placeholder: PropTypes.string,
   /**
-   * Text to display before the value
+   * Text or node to display before the value
    */
-  prefix: PropTypes.string,
+  prefix: PropTypes.node,
   /**
    * Is the input required
    */
@@ -78,9 +78,9 @@ const propTypes = {
    */
   spellCheck: PropTypes.bool,
   /**
-   * Text to display after the value
+   * Text or node to display after the value
    */
-  suffix: PropTypes.string,
+  suffix: PropTypes.node,
   /**
    * Changes the size of the input, giving it more or less padding and font size
    * @type {PropTypes.Requireable<Size>}

--- a/src/Components/Input/Input.scss
+++ b/src/Components/Input/Input.scss
@@ -8,7 +8,8 @@
   color: $INPUT_COLOR;
   width: 100%;
   max-width: 100%;
-  transition: box-shadow .1s linear, background .1s linear, border .1s linear;
+  transition: box-shadow 0.1s linear, background 0.1s linear,
+    border 0.1s linear;
 
   &:focus {
     outline: 0;
@@ -36,7 +37,7 @@
 }
 
 // remove Chrome browser clear button
-input[type="search"]::-webkit-search-cancel-button {
+input[type='search']::-webkit-search-cancel-button {
   -webkit-appearance: none;
 }
 
@@ -74,7 +75,6 @@ input[type="search"]::-webkit-search-cancel-button {
   border: $INPUT_BORDER;
   border-right: none;
   color: inherit;
-  pointer-events: none;
   flex: 0 0 auto;
 
   + .input {
@@ -88,7 +88,6 @@ input[type="search"]::-webkit-search-cancel-button {
   border-top-right-radius: $border-radius-1;
   border-bottom-right-radius: $border-radius-1;
   border: $INPUT_BORDER;
-  pointer-events: none;
   flex: 0 0 auto;
   margin-left: -1px;
 }


### PR DESCRIPTION
Sometimes you want to use a `button` as a suffix (e.g. copy this value). This PR fixes the prop warnings when it only allowed for type `string`.

Example:
<img width="717" alt="Screen Shot 2019-09-09 at 10 17 41 AM" src="https://user-images.githubusercontent.com/1447339/64551952-12702e00-d2eb-11e9-90f0-499599795ae5.png">
