### PR TITLE
fix (MenuItem): do not toggle the sub items when clicking a menuitem …

### DIFF
--- a/src/Components/MainMenu/MenuItem/MenuItem.js
+++ b/src/Components/MainMenu/MenuItem/MenuItem.js
@@ -167,9 +167,6 @@ class MenuItem extends React.Component {
               exact={item.exact}
               to={item.href}
               className="menu-item"
-              onClick={
-                hasSubItems ? this.handleToggleOpen : undefined
-              }
               aria-haspopup={hasSubItems}
               aria-expanded={isOpen}
               activeClassName="active"


### PR DESCRIPTION
After using the MainMenu for a little bit, and having menuitems that are links and have subItems, it's annoying that the menuitem subitems closes when clicking the top level item link.

Before: notice the "Channels" section collapses.
![before mov](https://user-images.githubusercontent.com/1447339/64561021-98e23b00-d2fe-11e9-882e-c9405e38af68.gif)

After: the Channels section stays open because it's no longer calling handleToggleOpen
![after mov](https://user-images.githubusercontent.com/1447339/64561147-dfd03080-d2fe-11e9-96f7-0b510ebd1adc.gif)