### PR TITLE
feat (Block): add displayBlock prop to Block component

### DIFF
--- a/src/Components/Block/Block.js
+++ b/src/Components/Block/Block.js
@@ -124,6 +124,11 @@ const propTypes = {
     PropTypes.string,
   ]),
   /**
+   * By default, Blocks are `display:flex`. This sets the block element to be a block element instead.
+   * When this is true, flex properties will be ignored
+   */
+  displayBlock: PropTypes.bool,
+  /**
    *
    * Apply a `solid 1px neutral-300` border to a specific side by passing one of the following strings:
    *
@@ -319,6 +324,7 @@ const propTypes = {
 const defaultProps = {
   as: 'div',
   direction: 'row',
+  displayBlock: false,
 };
 
 /**
@@ -340,6 +346,7 @@ class Block extends React.PureComponent {
       as,
       background,
       basis,
+      displayBlock,
       border,
       color,
       children,
@@ -375,10 +382,10 @@ class Block extends React.PureComponent {
       radius !== undefined ? getBorderRadiusClasses(radius) : null;
     const overflowClasses =
       overflow !== undefined ? getOverflowClasses(overflow) : null;
-    const directionClasses = getFlexPropertyClasses(
-      'flex',
-      direction,
-    );
+
+    const directionClasses = !displayBlock
+      ? getFlexPropertyClasses('flex', direction)
+      : null;
     const widthStyles = getDimensionClasses('width', width);
     const heightStyles = getDimensionClasses('height', height);
     const justifyClasses = getFlexPropertyClasses('justify', justify);
@@ -435,6 +442,9 @@ class Block extends React.PureComponent {
     Object.assign(mergedStyle, { width: widthStyles.styles });
     Object.assign(mergedStyle, { height: heightStyles.styles });
 
+    const isDisplayBlock =
+      displayBlock || (className ? className.includes('db') : false);
+
     const classes = classNames(
       directionClasses,
       overflowClasses,
@@ -453,7 +463,8 @@ class Block extends React.PureComponent {
       heightStyles.classes,
       color,
       {
-        flex: !truncate,
+        db: displayBlock,
+        flex: !isDisplayBlock && !truncate,
         [`bg-${background}`]: background,
         'flex-wrap': wrap,
         [`fs-${parsedTextSize}`]: parsedTextSize,
@@ -463,10 +474,11 @@ class Block extends React.PureComponent {
       },
       className,
     );
+    const calcDirection = displayBlock ? 'column' : direction;
 
     const spacingClasses =
       itemSpacing !== undefined
-        ? getItemSpacingClasses(direction, itemSpacing)
+        ? getItemSpacingClasses(calcDirection, itemSpacing)
         : null;
 
     let blockChildren;

--- a/src/Components/Block/Block.test.js
+++ b/src/Components/Block/Block.test.js
@@ -417,4 +417,37 @@ describe('Block', () => {
         expect(wrapper.prop('className')).toContain('truncate');
       });
     });
+
+  describe('displayBlock', () => {
+    it('applies the db class and removes flex class', () => {
+      const wrapper = shallow(<Block displayBlock>test</Block>);
+      expect(wrapper.prop('className')).toContain('db');
+      expect(wrapper.prop('className')).not.toContain('flex');
+    });
+    it('applies the db class and does not apply flex direction class', () => {
+      const wrapper = shallow(
+        <Block displayBlock direction="row">
+          <div>1</div>
+          <div>2</div>
+          <div>3</div>
+        </Block>,
+      );
+      expect(wrapper.prop('className')).toContain('db');
+      expect(wrapper.prop('className')).not.toContain('flex-row');
+      expect(wrapper.childAt(0).prop('className')).toBeUndefined();
+    });
+    it('applies the db class and adds correct spacing to children', () => {
+      const wrapper = shallow(
+        <Block displayBlock itemSpacing="4">
+          <div>1</div>
+          <div>2</div>
+          <div>3</div>
+        </Block>,
+      );
+      expect(wrapper.children()).toHaveLength(3);
+      expect(wrapper.childAt(0).prop('className')).toContain('mb-4');
+      expect(wrapper.childAt(1).prop('className')).toContain('mb-4');
+      expect(wrapper.childAt(2).prop('className')).toContain('mb-4');
+    });
+  });
 });

--- a/src/Components/Block/Readme.md
+++ b/src/Components/Block/Readme.md
@@ -49,6 +49,7 @@ import Badge from '../Badge/Badge';
     1
   </Block>
   <Block
+    className="db"
     width="100px"
     flex={true}
     padding="3"
@@ -112,28 +113,13 @@ Height can be set to a valid css height value.
 
 ```js
 <Block itemSpacing="3" height="100px">
-  <Block
-    height="44px"
-    padding="3"
-    background="blue-light"
-    marginBottom="4"
-  >
+  <Block height="44px" padding="3" background="blue-light">
     44px
   </Block>
-  <Block
-    height="4rem"
-    padding="3"
-    background="blue-light"
-    marginBottom="4"
-  >
+  <Block height="4rem" padding="3" background="blue-light">
     4rem (64px)
   </Block>
-  <Block
-    height="80%"
-    padding="3"
-    background="blue-light"
-    marginBottom="4"
-  >
+  <Block height="80%" padding="3" background="blue-light">
     80%
   </Block>
 </Block>


### PR DESCRIPTION
This provides an "escape hatch" to allow consumers of Block to make it `display: block` rather than always applying `display: flex`.

Previously, even if you add the utility class `db` to the `className` prop, you would end up with `<Block className="db flex" />` instead of `<Block className="db" />`. This also address that.