### PR TITLE
now exporting Types from root index file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 export * from './Components';
 export * from './Hooks';
+export * from './Types';
 export * from './Utils';


### PR DESCRIPTION
I noticed the Types definitions were not importable from the pebble package when consuming it in the Portal. When looking at the package.json for the build I see Types is trans-piled along with the other exported directories so I'm guessing the original intent was to export Types, so I added its export statement to the src/index.js file.