### PR TITLE
added FieldNumber export to Components/index.js

### DIFF
--- a/src/Components/index.js
+++ b/src/Components/index.js
@@ -12,6 +12,7 @@ export { default as DropdownItem } from './DropdownMenu/Components/DropdownItem'
 export { default as DropdownItemGroup } from './DropdownMenu/Components/DropdownItemGroup';
 export { default as FieldCheckbox } from './FieldCheckbox/FieldCheckbox';
 export { default as FieldDateTime } from './FieldDateTime/FieldDateTime';
+export { default as FieldNumber } from './FieldNumber/FieldNumber';
 export { default as FieldRadioGroup } from './FieldRadioGroup/FieldRadioGroup';
 export { default as FieldSelect } from './FieldSelect/FieldSelect';
 export { default as FieldText } from './FieldText/FieldText';


### PR DESCRIPTION
Adding export statement that exports FieldNumber to external consumers of pebble because it is currently not importable.