### PR TITLE
fix (Tabs): fix classNames that get applied to container

### DIFF
--- a/src/Components/Tabs/Tabs.js
+++ b/src/Components/Tabs/Tabs.js
@@ -55,7 +55,7 @@ export class Tabs extends React.PureComponent {
       ...rest
     } = this.props;
 
-    const classes = classNames('tabs', className);
+    const classes = classNames(className, 'relative');
 
     const getTabsMarkup = () => {
       if (tabs) {
@@ -129,18 +129,18 @@ export class Tabs extends React.PureComponent {
     };
 
     return (
-      <>
+      <Block displayBlock className={classes}>
         <Block
           as="ul"
           role="tablist"
-          className={classes}
+          className="tabs"
           onScroll={this.trackScrolling}
           {...rest}
         >
           {getTabsMarkup()}
         </Block>
         {getSelectedTabContent()}
-      </>
+      </Block>
     );
   }
 }


### PR DESCRIPTION
If a className is not supplied, then `undefined` gets added to list of classes. This fixes that.