### PR TITLE
fix (UseKeyboardEvent): always preventDefault and add key modifier option for ctrl, alt, shift, etc.

### DIFF
--- a/src/Hooks/UseKeyboardEvent.js
+++ b/src/Hooks/UseKeyboardEvent.js
@@ -1,5 +1,10 @@
 import { useEffect } from 'react';
 
+/**
+ * adds a keydown event listener to the window
+ * when the key(s) are pressed, it calls the callback
+ */
+
 export default (function(key, callback) {
   useEffect(
     function() {

--- a/src/Hooks/UseKeyboardEvent.test.js
+++ b/src/Hooks/UseKeyboardEvent.test.js
@@ -67,6 +67,23 @@ describe('useKeyboardEvent', () => {
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
+  it('it calls the callback with the correct value when the keydown event but the string is all caps', async () => {
+    const callback = jest.fn();
+    const { container } = render(
+      <TestComponent detectKeys="CTRL+s" callback={callback} />,
+    );
+    const keyDownEvent = new KeyboardEvent('keydown', {
+      key: 's',
+      bubbles: true,
+      which: 83,
+      code: 'KeyS',
+      ctrlKey: true,
+    });
+    fireEvent(container, keyDownEvent);
+    expect(callback).toHaveBeenCalledWith(keyDownEvent);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
   it('it calls the callback with the correct value when the keydown event is fired with meta + letter', async () => {
     const callback = jest.fn();
     const { container } = render(


### PR DESCRIPTION
This is one possible solution to #223. 

If the keyboard event does not originate from an `<input>` then preventDefault. 

In action locally (i'm pressing 's' and 'escape' keys):
![keyboard mov](https://user-images.githubusercontent.com/1447339/67134276-4a11a600-f1c6-11e9-89e7-054130d9897a.gif)
