### PR TITLE
chore: add react-merge-refs to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-onclickoutside": "^6.8.0",
     "react-popper": "^1.3.3",
     "react-select": "^3.0.4",
-    "react-toastify": "^5.3.2"
+    "react-toastify": "^5.3.2",
+    "react-merge-refs": "^1.0.0"
   },
   "peerDependencies": {
     "react": "^16.8.0",
@@ -65,7 +66,6 @@
     "publish-for-npm": "git+https://github.com/codefresh-plugins/npm-publish.git",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "react-merge-refs": "^1.0.0",
     "react-router-dom": "^5.0.0",
     "react-scripts": "3.0.1",
     "react-styleguidist": "^9.0.8",


### PR DESCRIPTION
1.9.0 package is broken because the react-merge-refs should be a dependency, not a dev dependency.