### PR TITLE
Allow FieldCheckbox labels to be hidden

### DIFF
--- a/src/Components/FieldCheckbox/FieldCheckbox.js
+++ b/src/Components/FieldCheckbox/FieldCheckbox.js
@@ -19,6 +19,10 @@ const propTypes = {
    */
   helpText: PropTypes.node,
   /**
+   * Visually hide the label
+   */
+  hideLabel: PropTypes.bool,
+  /**
    * The id attribute of the checkbox
    */
   id: PropTypes.string.isRequired,
@@ -59,6 +63,7 @@ const defaultProps = {
   isSelected: false,
   onChange: undefined,
   toggle: false,
+  hideLabel: false,
 };
 
 /**
@@ -74,6 +79,7 @@ function FieldCheckbox({
   isInvalid,
   className,
   helpText,
+  hideLabel,
   value,
   onChange,
   disabled,
@@ -81,20 +87,25 @@ function FieldCheckbox({
   validationText,
   ...rest
 }) {
-  const checkboxMarkup = () => (
-    <Checkbox
-      toggle={toggle}
-      key={id}
-      id={id}
-      isSelected={isSelected}
-      isInvalid={isInvalid}
-      onChange={onChange}
-      value={value}
-      disabled={disabled}
-      className={toggle ? 'toggle-input' : null}
-      {...rest}
-    />
-  );
+  const checkboxMarkup = () => {
+    const ariaLabelValue = hideLabel ? label : '';
+
+    return (
+      <Checkbox
+        aria-label={ariaLabelValue}
+        toggle={toggle}
+        key={id}
+        id={id}
+        isSelected={isSelected}
+        isInvalid={isInvalid}
+        onChange={onChange}
+        value={value}
+        disabled={disabled}
+        className={toggle ? 'toggle-input' : null}
+        {...rest}
+      />
+    );
+  };
 
   const labelMarkup = () => {
     if (toggle) {
@@ -131,20 +142,21 @@ function FieldCheckbox({
       );
     }
 
-    // normal checkbox
-    const labelClasses = classNames('db', {
-      red: isInvalid,
-    });
-
-    return (
-      <Block direction="column" className="ml-2">
-        <label htmlFor={id} className={labelClasses}>
-          {label}
-          {helpTextMarkup()}
-          {getValidationTextMarkup()}
-        </label>
-      </Block>
-    );
+    if (!hideLabel) {
+      // normal checkbox
+      const labelClasses = classNames('db', {
+        red: isInvalid,
+      });
+      return (
+        <Block direction="column" className="ml-2">
+          <label htmlFor={id} className={labelClasses}>
+            {label}
+            {helpTextMarkup()}
+            {getValidationTextMarkup()}
+          </label>
+        </Block>
+      );
+    }
   };
 
   const helpTextMarkup = () => {

--- a/src/Components/FieldCheckbox/FieldCheckbox.test.js
+++ b/src/Components/FieldCheckbox/FieldCheckbox.test.js
@@ -29,6 +29,14 @@ describe('FieldCheckbox', () => {
           .prop('className'),
       ).toContain('toggle');
     });
+
+    it('applies label as aria-label if hideLabel is true', () => {
+      const text = 'I am title text';
+      const wrapper = shallow(
+        <FieldCheckbox hideLabel id="1" label={text} />,
+      );
+      expect(wrapper.find('Checkbox').prop('aria-label')).toBe(text);
+    });
   });
 
   describe('helpTextMarkup', () => {

--- a/src/Components/FieldCheckbox/Readme.md
+++ b/src/Components/FieldCheckbox/Readme.md
@@ -6,6 +6,7 @@ import { useState } from 'react';
 function FieldCheckboxExample() {
   const [checkbox1, setCheckBox1] = useState(true);
   const [checkbox2, setCheckBox2] = useState(false);
+  const [hiddenLabel, setHiddenLabel] = useState(false);
   const [invalid, setInvalid] = useState(false);
   const [toggle, setToggle] = useState(true);
   const [toggleHelp, setToggleHelp] = useState(false);
@@ -41,6 +42,16 @@ function FieldCheckboxExample() {
         value="second"
         onChange={setCheckBox2}
         className="mb-5"
+      />
+
+      <FieldCheckbox
+        id="hiddenLabel"
+        label="hidden label"
+        isSelected={hiddenLabel}
+        value="first"
+        onChange={setHiddenLabel}
+        className="mb-5"
+        hideLabel
       />
 
       <FieldCheckbox

--- a/src/Components/FieldCheckbox/stories.js
+++ b/src/Components/FieldCheckbox/stories.js
@@ -7,6 +7,7 @@ import FieldCheckbox from './FieldCheckbox';
 function FieldCheckboxExample() {
   const [checkbox1, setCheckBox1] = useState(true);
   const [checkbox2, setCheckBox2] = useState(false);
+  const [hiddenLabel, setHiddenLabel] = useState(false);
   const [invalid, setInvalid] = useState(false);
   const [toggle, setToggle] = useState(true);
   const [toggleHelp, setToggleHelp] = useState(false);
@@ -42,6 +43,16 @@ function FieldCheckboxExample() {
         value="second"
         onChange={setCheckBox2}
         className="mb-5"
+      />
+
+      <FieldCheckbox
+        id="hiddenLabel"
+        label="hidden label"
+        isSelected={hiddenLabel}
+        value="first"
+        onChange={setHiddenLabel}
+        className="mb-5"
+        hideLabel
       />
 
       <FieldCheckbox


### PR DESCRIPTION
Sometimes we want to hide checkbox labels, such as when there are checkboxes for each row in a table/list. Label is still required, but it's applied to the aria-label for the checkbox input instead of being rendered on the page.

This does not apply to FieldToggles.