### PR TITLE
fix(LinkButton): use a span instead of a div

### DIFF
--- a/src/Components/LinkButton/LinkButton.js
+++ b/src/Components/LinkButton/LinkButton.js
@@ -130,11 +130,11 @@ const LinkButton = forwardRef((props, ref) => {
   );
 
   const content = (
-    <div className={contentClasses}>
+    <span className={contentClasses}>
       {leftIcon}
       {children && <span className="btn-label">{children}</span>}
       {rightIcon}
-    </div>
+    </span>
   );
 
   return disabled ? (


### PR DESCRIPTION
Using a span allows the button to be placed in places like a `<p>`
without throwing warnings 

Fixes: #316