### PR TITLE
chore: rename master to main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   push:
-    branches: [master]
+    branches: [main]
 jobs:
   lint:
     name: lint

--- a/.github/workflows/CreatePR.yml
+++ b/.github/workflows/CreatePR.yml
@@ -1,7 +1,7 @@
 name: Pull Request on Branch Push
 on:
   push:
-    branches-ignore: [master]
+    branches-ignore: [main]
 jobs:
   auto-pull-request:
     name: Create a PR
@@ -11,5 +11,5 @@ jobs:
         uses: vsoch/pull-request-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST_BRANCH: master
+          PULL_REQUEST_BRANCH: main
           PULL_REQUEST_DRAFT: true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 Follow the steps below to set up the repository to be run locally.
 
-The `master` branch is automatically deployed via [CodeFresh](https://g.codefresh.io/) to [pebble.istreamplanet.net](https://pebble.istreamplanet.net).
+The `main` branch is automatically deployed via [CodeFresh](https://g.codefresh.io/) to [pebble.istreamplanet.net](https://pebble.istreamplanet.net).
 
 #### Install the Packages
 


### PR DESCRIPTION
testing pushing a `main` branch up to get chromatic to build on it and then switch the branch to be the default one.

- [ ] Confirm chromatic still works when the branch is switched
- [ ] check storybook site to make sure it is still getting built (might require a codefresh change)